### PR TITLE
Regex fix for decimals

### DIFF
--- a/src/bot/message_handlers/freedom_units.py
+++ b/src/bot/message_handlers/freedom_units.py
@@ -15,7 +15,7 @@ def convert_to_freedom_units(update, context):
         match = match.group(0)
         print(match)
 
-        degrees_c = int(float(re.findall("\x2d?[0-9]*\x2e?[0-9]+", match)[0]))
+        degrees_c = float(re.findall("\x2d?[0-9]*\x2e?[0-9]+", match)[0])
         converted_units = (degrees_c * (9 / 5)) + 32
 
         output = f"{degrees_c} is {converted_units}f in freedom units"

--- a/src/bot/message_handlers/freedom_units.py
+++ b/src/bot/message_handlers/freedom_units.py
@@ -15,7 +15,7 @@ def convert_to_freedom_units(update, context):
         match = match.group(0)
         print(match)
 
-        degrees_c = int(re.findall("\d+", match)[0])
+        degrees_c = int(float(re.findall("\x2d?[0-9]*\x2e?[0-9]+", match)[0]))
         converted_units = (degrees_c * (9 / 5)) + 32
 
         output = f"{degrees_c} is {converted_units}f in freedom units"

--- a/src/bot/message_handlers/freedom_units.py
+++ b/src/bot/message_handlers/freedom_units.py
@@ -13,7 +13,6 @@ def convert_to_freedom_units(update, context):
 
     if match:
         match = match.group(0)
-        print(match)
 
         degrees_c = float(re.findall("\x2d?[0-9]*\x2e?[0-9]+", match)[0])
         converted_units = (degrees_c * (9 / 5)) + 32


### PR DESCRIPTION
Ripping the number part of the regex in the search call for use in the findall call
Before an input string of .3 would match as "3", now it should match as ".3"
int() would not like something like ".3" so Ive added a step to convert it first to a float then to an int, I dont want to figure out how to trim a float to something reasonable rn