### PR TITLE
Allow users to update their registered id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ CHANGELOG
 # Features
 - Get registered user MMR
 - Freedom units
-- Registration guards
+- Allow updating registered id

--- a/scripts/start_bot.sh
+++ b/scripts/start_bot.sh
@@ -6,7 +6,7 @@ git pull
 echo "activating venv"
 source venv/bin/activate
 
-echo "installing dependancies"
+echo "installing dependencies"
 pip install -r requirements.txt
 
 echo "starting bot"

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -8,7 +8,7 @@ from src import constants
 
 def save_user(user):
     session = create_session()
-    session.add(user)
+    session.merge(user)
     session.commit()
 
 
@@ -16,16 +16,14 @@ def run_register_command(update, context):
     chat_id = update.message.chat_id
     telegram_handle = update.message.from_user.username
 
-    if user_services.lookup_user_by_telegram_handle(telegram_handle):
-        return update.message.reply_text(
-            f"I already have a handle for @{telegram_handle}, sorry :("
-        )
-
     try:
         account_id = context.args[0]
-        new_user = User(telegram_handle, account_id, chat_id)
-        save_user(new_user)
-        update.message.reply_text(f"Successfully registered user {telegram_handle}")
+        
+        user = (user_services.lookup_user_by_telegram_handle(telegram_handle) or
+                User(telegram_handle, account_id, chat_id))
+        user.account_id = account_id
+        save_user(user)
+        update.message.reply_text(f"Successfully registered user {telegram_handle} as {account_id}")
     except (IndexError, ValueError):
         update.message.reply_text("No dota friend ID was given")
 


### PR DESCRIPTION
I changed `session.add(user)` to `session.merge(user)`, which seems like a foolproof way to do both creating and updating in one. I also made sure that `run_register_command` can handle both use cases.