### PR TITLE
Commands by username, case insensitive usernames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,5 @@ CHANGELOG
 # Bugfixes
 
 # Features
+- Optional user argument in /rank, /lastmatch and /recents
+- Usernames are now stored and retrieved case-insensitive. Existing data needs to be migrated to all-lowercase usernames in the database

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 CHANGELOG
 
 
-# Next [1.0.3]
+# Next [1.0.4]
 
 # Env Vars
 
@@ -10,4 +10,4 @@ CHANGELOG
 
 # Features
 - Optional user argument in /rank, /lastmatch and /recents
-- Usernames are now stored and retrieved case-insensitive. Existing data needs to be migrated to all-lowercase usernames in the database
+- Usernames are now stored and retrieved case-insensitive

--- a/src/bot/commands/match_commands.py
+++ b/src/bot/commands/match_commands.py
@@ -12,7 +12,6 @@ def run_last_match_command(update, context):
         telegram_handle = context.args[0]
     except(IndexError, ValueError):
         telegram_handle = update.message.from_user.username
-    telegram_handle = telegram_handle.replace("@", "")
 
     user = user_services.lookup_user_by_telegram_handle(telegram_handle)
 

--- a/src/bot/commands/match_commands.py
+++ b/src/bot/commands/match_commands.py
@@ -8,7 +8,11 @@ from src.bot.commands import helpers
 
 def run_last_match_command(update, context):
     chat_id = update.message.chat_id
-    telegram_handle = update.message.from_user.username
+    try:
+        telegram_handle = context.args[0]
+    except(IndexError, ValueError):
+        telegram_handle = update.message.from_user.username
+    telegram_handle = telegram_handle.replace("@", "")
 
     user = user_services.lookup_user_by_telegram_handle(telegram_handle)
 

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -35,32 +35,20 @@ def run_register_command(update, context):
 def run_get_player_recents_command(update, context):
     chat_id = update.message.chat_id
 
-    # Assume default if no arguments are given
-    if not context.args:
-        registered_user = user_services.lookup_user_by_telegram_handle(
-            update.message.from_user.username
-        )
-    else:
-        # Try to match the first argument against the database for usernames
-        # If the result is not a valid user, try the second one
-        # If the result still isn't valid, assume the user's own name
+    # Assume defaults
+    registered_user = user_services.lookup_user_by_telegram_handle(
+        update.message.from_user.username
+    )
+    limit = constants.QUERY_PARAMETERS.RESPONSE_LIMIT.value
+
+    for arg in context.args:
+        user = user_services.lookup_user_by_telegram_handle(arg)
+        if user:
+            registered_user = user
         try:
-            registered_user = user_services.lookup_user_by_telegram_handle(
-                context.args[0].replace("@", "")
-            )
+            limit = int(arg)
         except:
             pass
-        if not registered_user:
-            try:
-                registered_user = user_services.lookup_user_by_telegram_handle(
-                    context.args[1].replace("@", "")
-                )
-            except:
-                pass
-            if not registered_user:
-                registered_user = user_services.lookup_user_by_telegram_handle(
-                    update.message.from_user.username
-                )
 
     if not registered_user:
         update.message.reply_text(
@@ -68,19 +56,6 @@ def run_get_player_recents_command(update, context):
         )
 
     account_id = registered_user.account_id
-
-    if not context.args:
-        limit = constants.QUERY_PARAMETERS.RESPONSE_LIMIT.value
-    else:
-        try:
-            limit = context.args[0]
-            limit = int(limit)
-        except:
-            try:
-                limit = context.args[1]
-                limit = int(limit)
-            except:
-                limit = constants.QUERY_PARAMETERS.RESPONSE_LIMIT.value
 
     if limit > 20:
         limit = 20

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -70,8 +70,10 @@ def run_get_player_recents_command(update, context):
 
 def run_get_player_rank_command(update, context):
     chat_id = update.message.chat_id
-    telegram_handle = update.message.from_user.username
-
+    try:
+        telegram_handle = context.args[0]
+    except(IndexError, ValueError):
+        telegram_handle = update.message.from_user.username
     telegram_handle = telegram_handle.replace("@", "")
 
     registered_user = user_services.lookup_user_by_telegram_handle(telegram_handle)
@@ -93,5 +95,5 @@ def run_get_player_rank_command(update, context):
 
     rank = helpers.map_rank_tier_to_string(rank_tier)
 
-    output_message = f"{persona_name} is {rank}"
+    output_message = f"{persona_name} (@{telegram_handle}) is {rank}"
     update.message.reply_text(output_message)

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -77,7 +77,7 @@ def run_get_player_rank_command(update, context):
         telegram_handle = context.args[0]
     except(IndexError, ValueError):
         telegram_handle = update.message.from_user.username
-    telegram_handle = telegram_handle.replace("@", "")
+    telegram_handle = telegram_handle
 
     registered_user = user_services.lookup_user_by_telegram_handle(telegram_handle)
 

--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -7,6 +7,7 @@ from src import constants
 
 
 def save_user(user):
+    user.telegram_handle = user.telegram_handle.lower()
     session = create_session()
     session.merge(user)
     session.commit()

--- a/src/bot/services/user_services.py
+++ b/src/bot/services/user_services.py
@@ -3,6 +3,7 @@ from src.bot.models.sessions import create_session
 
 
 def lookup_user_by_telegram_handle(telegram_handle):
+    telegram_handle = telegram_handle.lower()
     session = create_session()
     bot_user = (
         session.query(User).filter(User.telegram_handle == telegram_handle).first()

--- a/src/bot/services/user_services.py
+++ b/src/bot/services/user_services.py
@@ -3,7 +3,7 @@ from src.bot.models.sessions import create_session
 
 
 def lookup_user_by_telegram_handle(telegram_handle):
-    telegram_handle = telegram_handle.lower()
+    telegram_handle = telegram_handle.lower().replace("@", "")
     session = create_session()
     bot_user = (
         session.query(User).filter(User.telegram_handle == telegram_handle).first()

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,7 +6,7 @@ DEFAULT_LOG_LEVEL = "debug"
 
 
 USER_NOT_REGISTERED_MESSAGE = (
-    "I didn't find your telegram name.. have you register or changed your telegram @?"
+    "I couldn't find that Telegram username, please make sure to register your friend ID using `/register`"
 )
 
 
@@ -16,11 +16,12 @@ BAD_RESPONSE_MESSAGE = "Something went wrong, I didn't get a good response :("
 HELP_TEXT = """
     *Commands*
     `\/register <your steam friend id here>` :: Register your telegram handle to your steam friend id for look ups\. Example :: `\/register 55678920`\n
-    `\/help` :: display this help message\n
+    `\/help` :: Display this help message\n
     `\/status` :: Check to see if services are running, `OK` means everything is good to go\n
-    `\/recents <limit:optional>` :: Look up your most recent matches, defaults to 5 if limit is not defined\. Must have account id registered using `/register`\. Example :: `\/recents` or `\/recents 10` for 10 most recent matches\n
+    `\/recents <user:optional> <limit:optional>` :: Look up someone's most recent matches\. Defaults to 5 if limit is not defined and to you if user is not defined\. Must have account id registered using `/register`\. Example :: `\/recents`, `\/recents 10` for 10 most recent matches, `\/recents danvb` for Daniel's last games, `\/recents 20 KittyKirov` for Kirov's last 20 games\n
     `\/match <match_id>` :: Get detailed stats about the outcome of a match\n
-    `\/lastmatch` :: Gets the last match you played\. Must use register command prior to using this command
+    `\/lastmatch <user:optional>` :: Gets the last match someone played\. Defaults to you if no argument is given\. User must be registered for this to work \n
+    `\/rank <user:optional>` :: Gets a user's current medal\. Defaults to you if no argument is given\. User must be registered for this to work
     """
 
 


### PR DESCRIPTION
This PR makes two changes:
- Allow users to ask for someone else's data when running /lastmatch, /recents or /rank. Simply add a telegram username (@ optional) to the command and the bot will try to match it to its database.
- Add case insensitivity to username storage. Usernames stored in the database from here on out will be in all-lowercase, and trying to find a user by their username will also convert to lowercase internally. ⚠ **This requires old capitalized usernames to be properly migrated!**

This PR also closes #12.