### PR TITLE
Fix redundant @ in /rank

### DIFF
--- a/src/bot/commands/user_commands.py
+++ b/src/bot/commands/user_commands.py
@@ -77,7 +77,6 @@ def run_get_player_rank_command(update, context):
         telegram_handle = context.args[0]
     except (IndexError, ValueError):
         telegram_handle = update.message.from_user.username
-    telegram_handle = telegram_handle
 
     registered_user = user_services.lookup_user_by_telegram_handle(telegram_handle)
 
@@ -98,5 +97,5 @@ def run_get_player_rank_command(update, context):
 
     rank = helpers.map_rank_tier_to_string(rank_tier)
 
-    output_message = f"{persona_name} (@{telegram_handle}) is {rank}"
+    output_message = f"{persona_name} (@{registered_user.telegram_handle}) is {rank}"
     update.message.reply_text(output_message)


### PR DESCRIPTION
/rank now always responds with the username as stored in the database, so it never has an extra @ in front of it.