### PR TITLE
Grouped message handlers, liberal units, you're welcome :)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ CHANGELOG
 # Env Vars
 
 # Bugfixes
+- Message handlers with the same trigger (the ones that trigger off all messages) are now grouped separately so they won't prevent each other from triggering
 
 # Features
+- Slarkbot now says you're welcome when you thank him :)
 
 # Commands
+- Typing degrees in Fahrenheit now converts to liberal units
 

--- a/src/bot/bot_factory.py
+++ b/src/bot/bot_factory.py
@@ -22,16 +22,16 @@ def create_bot():
     updater = Updater(bot_token, use_context=True)
     dp = updater.dispatcher
 
-    dp.add_handler(CommandHandler("status", health_check_command.run_health_check), 0)
-    dp.add_handler(CommandHandler("register", user_commands.run_register_command), 0)
-    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command), 0)
+    dp.add_handler(CommandHandler("status", health_check_command.run_health_check))
+    dp.add_handler(CommandHandler("register", user_commands.run_register_command))
+    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command))
     dp.add_handler(
-        CommandHandler("recents", user_commands.run_get_player_recents_command), 0
+        CommandHandler("recents", user_commands.run_get_player_recents_command)
     )
-    dp.add_handler(CommandHandler("help", help_command.run_help_command), 0)
-    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command), 0)
-    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id), 0)
-    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command), 0)
+    dp.add_handler(CommandHandler("help", help_command.run_help_command))
+    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command))
+    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id))
+    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command))
 
     # Group handlers with the same trigger separately
     # to ensure they don't conflict with each other

--- a/src/bot/bot_factory.py
+++ b/src/bot/bot_factory.py
@@ -9,6 +9,7 @@ from src.bot.commands import match_commands
 from src.bot.commands import changelog_command
 
 from src.bot.message_handlers.freedom_units import convert_to_freedom_units
+from src.bot.message_handlers.liberal_units import convert_to_liberal_units
 from src.bot.message_handlers.youre_welcome import say_youre_welcome
 
 from src.constants import LOG_LEVEL_MAP
@@ -22,19 +23,26 @@ def create_bot():
     dp = updater.dispatcher
 
     dp.add_handler(CommandHandler("status", health_check_command.run_health_check), 0)
-    dp.add_handler(CommandHandler("register", user_commands.run_register_command), 1)
-    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command), 2)
+    dp.add_handler(CommandHandler("register", user_commands.run_register_command), 0)
+    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command), 0)
     dp.add_handler(
-        CommandHandler("recents", user_commands.run_get_player_recents_command), 3
+        CommandHandler("recents", user_commands.run_get_player_recents_command), 0
     )
-    dp.add_handler(CommandHandler("help", help_command.run_help_command), 4)
-    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command), 5)
-    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id), 6)
-    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command), 7)
+    dp.add_handler(CommandHandler("help", help_command.run_help_command), 0)
+    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command), 0)
+    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id), 0)
+    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command), 0)
 
-    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, say_youre_welcome))
+    # Group handlers with the same trigger separately
+    # to ensure they don't conflict with each other
     dp.add_handler(
-        MessageHandler(Filters.text & ~Filters.command, convert_to_freedom_units), 8
+        MessageHandler(Filters.text & ~Filters.command, say_youre_welcome), 1
+    )
+    dp.add_handler(
+        MessageHandler(Filters.text & ~Filters.command, convert_to_freedom_units), 2
+    )
+    dp.add_handler(
+        MessageHandler(Filters.text & ~Filters.command, convert_to_liberal_units), 3
     )
 
     return updater, logger

--- a/src/bot/bot_factory.py
+++ b/src/bot/bot_factory.py
@@ -9,6 +9,7 @@ from src.bot.commands import match_commands
 from src.bot.commands import changelog_command
 
 from src.bot.message_handlers.freedom_units import convert_to_freedom_units
+from src.bot.message_handlers.youre_welcome import say_youre_welcome
 
 from src.constants import LOG_LEVEL_MAP
 
@@ -31,6 +32,7 @@ def create_bot():
     dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id), 6)
     dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command), 7)
 
+    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, say_youre_welcome))
     dp.add_handler(
         MessageHandler(Filters.text & ~Filters.command, convert_to_freedom_units), 8
     )

--- a/src/bot/bot_factory.py
+++ b/src/bot/bot_factory.py
@@ -20,19 +20,19 @@ def create_bot():
     updater = Updater(bot_token, use_context=True)
     dp = updater.dispatcher
 
-    dp.add_handler(CommandHandler("status", health_check_command.run_health_check))
-    dp.add_handler(CommandHandler("register", user_commands.run_register_command))
-    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command))
+    dp.add_handler(CommandHandler("status", health_check_command.run_health_check), 0)
+    dp.add_handler(CommandHandler("register", user_commands.run_register_command), 1)
+    dp.add_handler(CommandHandler("rank", user_commands.run_get_player_rank_command), 2)
     dp.add_handler(
-        CommandHandler("recents", user_commands.run_get_player_recents_command)
+        CommandHandler("recents", user_commands.run_get_player_recents_command), 3
     )
-    dp.add_handler(CommandHandler("help", help_command.run_help_command))
-    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command))
-    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id))
-    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command))
+    dp.add_handler(CommandHandler("help", help_command.run_help_command), 4)
+    dp.add_handler(CommandHandler("lastmatch", match_commands.run_last_match_command), 5)
+    dp.add_handler(CommandHandler("match", match_commands.run_get_match_by_match_id), 6)
+    dp.add_handler(CommandHandler("changes", changelog_command.run_changes_command), 7)
 
     dp.add_handler(
-        MessageHandler(Filters.text & ~Filters.command, convert_to_freedom_units)
+        MessageHandler(Filters.text & ~Filters.command, convert_to_freedom_units), 8
     )
 
     return updater, logger

--- a/src/bot/message_handlers/freedom_units.py
+++ b/src/bot/message_handlers/freedom_units.py
@@ -9,8 +9,6 @@ def convert_to_freedom_units(update, context):
         re.M | re.I,
     )
 
-    print(match)
-
     if match:
         match = match.group(0)
 

--- a/src/bot/message_handlers/liberal_units.py
+++ b/src/bot/message_handlers/liberal_units.py
@@ -1,0 +1,19 @@
+import re
+
+
+def convert_to_liberal_units(update, context):
+    text = update.message.text
+    match = re.search(
+        """(?:(?<=[\r\n\t\f\v ])|^)(\x2d?[0-9]*\x2e?[0-9]+[Ff])(?:(?=[\r\n\t\f\v ])|$)""",
+        text,
+        re.M | re.I,
+    )
+
+    if match:
+        match = match.group(0)
+
+        degrees_f = float(re.findall("\x2d?[0-9]*\x2e?[0-9]+", match)[0])
+        converted_units = (degrees_f - 32) * 5 / 9
+
+        output = f"{degrees_f} is {converted_units}c in liberal units"
+        update.message.reply_text(output)

--- a/src/bot/message_handlers/youre_welcome.py
+++ b/src/bot/message_handlers/youre_welcome.py
@@ -1,0 +1,7 @@
+def say_youre_welcome(update, context):
+    text = update.message.text
+
+    print("TEXT ", text)
+
+    if text.lower() is "thanks slarkbot":
+        update.message.reply_text("You're welcome :)")

--- a/src/bot/message_handlers/youre_welcome.py
+++ b/src/bot/message_handlers/youre_welcome.py
@@ -1,7 +1,5 @@
 def say_youre_welcome(update, context):
     text = update.message.text
 
-    print("TEXT ", text)
-
-    if text.lower() is "thanks slarkbot":
+    if text.lower() == "thanks slarkbot":
         update.message.reply_text("You're welcome :)")


### PR DESCRIPTION
Message handlers are now grouped separately if they have the same trigger, which right now applies only to handlers that do not trigger off a command. By default, up to one handler per group can trigger on the same message, so when these handlers are in the same group, only the first one will actually do anything. Separating them means they all trigger individually. The command handlers are all in the default group (0), they should never conflict.

This PR also contains a handler for F to C conversion and for saying you're welcome :)